### PR TITLE
There is a misuse of gai_strerror() and strerror() functions

### DIFF
--- a/Socket.cpp
+++ b/Socket.cpp
@@ -17,7 +17,7 @@ Socket::Socket(int domain, int type, int protocol)
     sock = socket(domain, type , protocol);
     if (sock < 0) {
         //exit(1);
-        cerr << "opening socket error: " << gai_strerror(errno) << endl;
+        cerr << "opening socket error: " << strerror(errno) << endl;
     }
     address_info.ai_family = domain;
     address_info.ai_socktype = type;
@@ -37,7 +37,7 @@ int Socket::bind(string ip, string port){
         int status = ::bind(sock, (struct sockaddr*)&addr, sizeof(addr));
         if (status < 0) {
             //exit(1);
-            cerr << "bind error: " << gai_strerror(errno) << endl;
+            cerr << "bind error: " << strerror(errno) << endl;
         }
         return status;
     }
@@ -48,7 +48,7 @@ int Socket::bind(string ip, string port){
     struct addrinfo *res;
     address_info.ai_flags = AI_PASSIVE;
     if ((status = getaddrinfo(ip.c_str(), port.c_str(), &address_info, &res)) != 0) {
-        cerr << "getaddrinfo error: " << gai_strerror(errno) << endl;
+        cerr << "getaddrinfo error: " << gai_strerror(status) << endl;
         //exit(1);
         return status;
     }
@@ -58,7 +58,7 @@ int Socket::bind(string ip, string port){
     status = ::bind(sock, address_info.ai_addr, address_info.ai_addrlen);
     if (status < 0) {
         //exit(1);
-        cerr << "bind error: " << gai_strerror(errno) << endl;
+        cerr << "bind error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -73,7 +73,7 @@ int Socket::connect(string ip, string port){
         int status = ::connect(sock, (struct sockaddr*)&addr, sizeof(addr));
         if (status < 0) {
             //exit(1);
-            cerr << "connect error: " << gai_strerror(errno) << endl;
+            cerr << "connect error: " << strerror(errno) << endl;
         }
         return status;
     }
@@ -84,7 +84,7 @@ int Socket::connect(string ip, string port){
     struct addrinfo *res;
     int status;
     if ((status = getaddrinfo(ip.c_str(), port.c_str(), &address_info, &res)) != 0){
-        cerr << "getaddrinfo error: " << gai_strerror(errno);
+        cerr << "getaddrinfo error: " << gai_strerror(status);
         //exit(1);
         return status;
     }
@@ -94,7 +94,7 @@ int Socket::connect(string ip, string port){
     status = ::connect(sock, address_info.ai_addr, address_info.ai_addrlen);
     if (status < 0) {
         //exit(1);
-        cerr << "connect error: " << gai_strerror(status) << endl;
+        cerr << "connect error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -104,7 +104,7 @@ int Socket::listen(int max_queue){
     status = ::listen(sock,max_queue);
     if (status < 0) {
         //exit(1);
-        cerr << "listen error: " << gai_strerror(errno) << endl;
+        cerr << "listen error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -116,7 +116,7 @@ Socket* Socket::accept(){
     int newsock = ::accept(sock, (struct sockaddr *)&their_addr, &addr_size);
     if (newsock < 0) {
         //exit(1);
-        cerr << "accept error: " << gai_strerror(errno) << endl;
+        cerr << "accept error: " << strerror(errno) << endl;
     }
     Socket *newSocket = new Socket(address_info.ai_family,address_info.ai_socktype,address_info.ai_protocol);
     newSocket->sock = newsock;
@@ -124,9 +124,9 @@ Socket* Socket::accept(){
     
     char host[NI_MAXHOST];
     int status = getnameinfo((struct sockaddr *)&their_addr, sizeof(their_addr), host, sizeof(host), NULL, 0, NI_NUMERICHOST);
-    if (status < 0) {
+    if (status != 0) {
         //exit(1);
-        cerr << "getnameinfo error: " << gai_strerror(errno) << endl;
+        cerr << "getnameinfo error: " << gai_strerror(status) << endl;
     }
     newSocket->address = host;
     newSocket->address_info.ai_family = their_addr.ss_family;
@@ -139,7 +139,7 @@ int Socket::socket_write(string msg){
     int status = (int)send(sock, buf, len, 0);
     if (status < 0) {
         //exit(1);
-        cerr << "write error: " << gai_strerror(errno) << endl;
+        cerr << "write (send) error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -157,7 +157,7 @@ int Socket::socket_safe_read(string &buf,int len,int seconds){
     int status = (int)recv(sock, buffer, len-1, 0);
     if (status < 0) {
         //exit(1);
-        cerr << "read error: " << gai_strerror(errno) << endl;
+        cerr << "read error: " << strerror(errno) << endl;
     }
     buf = string(buffer);
     return status;
@@ -168,7 +168,7 @@ int Socket::socket_read(string &buf,int len){
     int status = (int)recv(sock, buffer, len-1, 0);
     if (status < 0) {
         //exit(1);
-        cerr << "read error: " << gai_strerror(errno) << endl;
+        cerr << "read error: " << strerror(errno) << endl;
     }
     buf = string(buffer);
     return status;
@@ -181,7 +181,7 @@ int Socket::socket_writeTo(string msg, string ip, string port){
     struct addrinfo *res;
     int status;
     if ((status = getaddrinfo(ip.c_str(), port.c_str(), &address_info, &res)) != 0){
-        cerr << "getaddrinfo error: " << gai_strerror(errno) << endl;
+        cerr << "getaddrinfo error: " << gai_strerror(status) << endl;
         //exit(1);
         return status;
     }
@@ -191,7 +191,7 @@ int Socket::socket_writeTo(string msg, string ip, string port){
     status = (int)sendto(sock, buf, len, 0, address_info.ai_addr, address_info.ai_addrlen);
     if (status < 0) {
         //exit(1);
-        cerr << "writeTo error: " << gai_strerror(errno) << endl;
+        cerr << "writeTo error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -201,7 +201,7 @@ int Socket::socket_readFrom(string &buf, int len, string ip, string port){
     struct addrinfo *res;
     int status;
     if ((status = getaddrinfo(ip.c_str(), port.c_str(), &address_info, &res)) != 0){
-        cerr << "getaddrinfo error: " << gai_strerror(errno) << endl;
+        cerr << "getaddrinfo error: " << gai_strerror(status) << endl;
         //exit(1);
         return status;
     }
@@ -211,7 +211,7 @@ int Socket::socket_readFrom(string &buf, int len, string ip, string port){
     status = (int)recvfrom(sock, buffer, len-1, 0,address_info.ai_addr, &address_info.ai_addrlen);
     if (status < 0) {
         //exit(1);
-        cerr << "readFrom error: " << gai_strerror(errno) << endl;
+        cerr << "readFrom error: " << strerror(errno) << endl;
     }
     buf = string(buffer); 
     return status;
@@ -222,7 +222,7 @@ int Socket::socket_set_opt(int level, int optname, void* optval){
     int status = ::setsockopt(sock,level,optname,optval,len);
     if (status < 0) {
         //exit(1);
-        cerr << "socket_set_opt error: " << gai_strerror(errno) << endl;
+        cerr << "socket_set_opt error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -232,7 +232,7 @@ int Socket::socket_get_opt(int level, int optname, void* optval){
     int status = ::getsockopt(sock,level,optname,optval,&len);
     if (status < 0) {
         //exit(1);
-        cerr << "socket_get_opt error: " << gai_strerror(errno) << endl;
+        cerr << "socket_get_opt error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -241,13 +241,13 @@ int Socket::set_blocking(){
     long status = fcntl(sock, F_GETFL, NULL);
     if (status < 0) {
         //exit(1);
-        cerr << "set_blocking(get) error: " << gai_strerror(errno) << endl;
+        cerr << "set_blocking(get) error: " << strerror(errno) << endl;
     }
     status &= (~O_NONBLOCK);
     status = fcntl(sock, F_SETFL, status);
     if (status < 0) {
         //exit(1);
-        cerr << "set_blocking(set) error: " << gai_strerror(errno) << endl;
+        cerr << "set_blocking(set) error: " << strerror(errno) << endl;
     }
     return (int)status;
 }
@@ -256,13 +256,13 @@ int Socket::set_non_blocking(){
     long status = fcntl(sock, F_GETFL, NULL);
     if (status < 0) {
         //exit(1);
-        cerr << "set_non_blocking(get) error: " << gai_strerror(errno) << endl;
+        cerr << "set_non_blocking(get) error: " << strerror(errno) << endl;
     }
     status |= O_NONBLOCK;
     status = fcntl(sock, F_SETFL, status);
     if (status < 0) {
         //exit(1);
-        cerr << "set_non_blocking(set) error: " << gai_strerror(errno) << endl;
+        cerr << "set_non_blocking(set) error: " << strerror(errno) << endl;
     }
     return (int)status;
 }
@@ -271,7 +271,7 @@ int Socket::socket_shutdown(int how){
     int status = ::shutdown(sock, how);
     if (status < 0) {
         //exit(1);
-        cerr << "shutdown error: " << gai_strerror(errno) << endl;
+        cerr << "shutdown error: " << strerror(errno) << endl;
     }
     return status;
 }
@@ -331,7 +331,7 @@ int Socket::select(vector<Socket> *reads, vector<Socket> *writes, vector<Socket>
     
     if (result < 0) {
         //exit(1);
-        cerr << "select error: " << gai_strerror(errno) << endl;
+        cerr << "select error: " << strerror(errno) << endl;
     }
     if (reads != NULL) {
         for (int i = (int)reads->size()-1; i >= 0; i--) {


### PR DESCRIPTION
`gai_strerror()` must be used only for address info functions and its argument is the return value of those functions.
`strerror()` must be used in all other cases taking `errno` as argument.